### PR TITLE
[007-13-3] Rename AuthType OIDC values + Auth subtype classes

### DIFF
--- a/src/main/kotlin/io/apiable/gateways/adapter/Gateway.kt
+++ b/src/main/kotlin/io/apiable/gateways/adapter/Gateway.kt
@@ -157,7 +157,7 @@ interface AuthGateway {
     /**
      * Create a Key
      *
-     * AuthType.BASIC_API_KEY
+     * AuthType.API_KEY
      * Callout to:
      *    AWS: java-client: createKeyForUsagePlan
      *    Kong:
@@ -177,7 +177,7 @@ interface AuthGateway {
      *       PUT https://management.azure.com$url/subscriptions/${subscription.id}?api-version=${conf.version}&appType=portal
      *
      *
-     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, INTERMEDIATE_CLIENT_CREDENTIAL, ADVANCED_CODE_FLOW
+     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, CLIENT_SECRET_BASIC, ADVANCED_CODE_FLOW
      * Callout to:
      *    AWS: not supported: Can be combined with the Apiable Auth Platform - Curity
      *    Kong:
@@ -194,19 +194,19 @@ interface AuthGateway {
     /**
      * Rotate the Secret / API Key
      *
-     * AuthType.BASIC_API_KEY
+     * AuthType.API_KEY
      * Generates a new API key, replacing the existing one.
      * Callout to:
      *    AWS: java-client: deleteKey/createKey
      *
-     * AuthType.INTERMEDIATE_CLIENT_CREDENTIAL, ADVANCED_CODE_FLOW
+     * AuthType.CLIENT_SECRET_BASIC, ADVANCED_CODE_FLOW
      * Rotates the OAuth2 client secret for the existing client application.
      * */
     fun rotateSecret(conf: Conf, auth: AuthCreate): Auth
 
     /**
      *
-     * AuthType.BASIC_API_KEY
+     * AuthType.API_KEY
      *
      * Callout to:
      *    AWS: java-client: deleteKey/createKey
@@ -230,7 +230,7 @@ interface AuthGateway {
      *
      *
      *
-     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, INTERMEDIATE_CLIENT_CREDENTIAL, ADVANCED_CODE_FLOW
+     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, CLIENT_SECRET_BASIC, ADVANCED_CODE_FLOW
      *
      * Updates a Client on a Gateway
      *
@@ -247,14 +247,14 @@ interface AuthGateway {
 
     /**
      * Revoke the Key
-     * AuthType.BASIC_API_KEY
+     * AuthType.API_KEY
      *
      * Callout to:
      *    AWS: java-client: deleteKey
      *    Kong: DELETE ${conf.url}/consumers/$username
      *    Azure: DELETE: https://management.azure.com${subscription.integrationId}?api-version=${conf.version}"
      *
-     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, INTERMEDIATE_CLIENT_CREDENTIAL, ADVANCED_CODE_FLOW
+     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, CLIENT_SECRET_BASIC, ADVANCED_CODE_FLOW
      * Updates a Client on a Gateway
      *
      * Callout to:
@@ -268,7 +268,7 @@ interface AuthGateway {
 
     /**
      * Read the key
-     * AuthType.BASIC_API_KEY
+     * AuthType.API_KEY
      *
      * Callout to:
      *    AWS: java-client: getKeyForSubscription
@@ -277,7 +277,7 @@ interface AuthGateway {
      *
      *
      *
-     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, INTERMEDIATE_CLIENT_CREDENTIAL, ADVANCED_CODE_FLOW
+     * AuthType.INTERMEDIATE_PRE_GENERATE_TOKEN, CLIENT_SECRET_BASIC, ADVANCED_CODE_FLOW
      * Not implemented yet
      * */
     fun readAuth(conf: Conf, auth: AuthRead): Auth

--- a/src/main/kotlin/io/apiable/gateways/adapter/model/Auth.kt
+++ b/src/main/kotlin/io/apiable/gateways/adapter/model/Auth.kt
@@ -44,19 +44,19 @@ interface AuthClientRevoke: AuthRevoke {
 
 data class CalloutExamples(val curl: String)
 
-data class AuthBasicApiKey(
+data class AuthApiKey(
     override var id: String,
     override var integrationId: String,
     val key: String,
     val key2: String? = null
 ) : Auth
 
-data class AuthBasicApiKeyRead(
+data class AuthApiKeyRead(
     override var integrationId: String,
     override var id: String = integrationId
 ) : AuthRead
 
-data class AuthBasicApiKeyCreate(
+data class AuthApiKeyCreate(
     override var id: String,
     override var integrationId: String,
     override val plan: Plan,
@@ -67,13 +67,13 @@ data class AuthBasicApiKeyCreate(
     val key2: String? = null
 ) : AuthCreate, AuthUpdate
 
-data class AuthBasicApiKeyRevoke(
+data class AuthApiKeyRevoke(
     override var integrationId: String,
     override var id: String = integrationId
 ) : AuthRevoke
 
 // https://learn.microsoft.com/en-us/linkedin/shared/authentication/client-credentials-flow?context=linkedin%2Fcontext
-data class AuthIntermediateClientCredential(
+data class AuthClientSecretBasic(
     override var id: String,
     override var integrationId: String,
     var clientId: String,
@@ -84,7 +84,7 @@ data class AuthIntermediateClientCredential(
     var examples: CalloutExamples? = null,
     var enabled: Boolean? = true
 ) : Auth {
-    fun appendExamples(url: String, clientId: String) = AuthIntermediateClientCredential(
+    fun appendExamples(url: String, clientId: String) = AuthClientSecretBasic(
         id = id,
         integrationId = integrationId,
         clientId = clientId,
@@ -118,14 +118,14 @@ data class AuthIntermediateClientCredential(
     )
     }
 
-data class AuthIntermediateClientCredentialRead(
+data class AuthClientSecretBasicRead(
     override var integrationId: String,
     override var id: String = integrationId,
     var redirectUri: String? = null,
     var clientId: String? = null
 ) : AuthRead
 
-data class AuthIntermediateClientCredentialCreate(
+data class AuthClientSecretBasicCreate(
     override var id: String,
     override var integrationId: String,
     override val plan: Plan,
@@ -136,7 +136,7 @@ data class AuthIntermediateClientCredentialCreate(
     override var appendToToken: Map<String,String>? = null,
 ) : AuthClientCreate
 
-data class AuthIntermediateClientCredentialUpdate(
+data class AuthClientSecretBasicUpdate(
     override var id: String,
     override var integrationId: String,
     override val plan: Plan,
@@ -151,7 +151,7 @@ data class AuthIntermediateClientCredentialUpdate(
     override val lastAuth: Auth? = null,
 ) : AuthClientUpdate
 
-data class AuthIntermediateClientCredentialRevoke(
+data class AuthClientSecretBasicRevoke(
     override var integrationId: String,
     override var id: String = integrationId,
     override var registrationClientUri: String

--- a/src/main/kotlin/io/apiable/gateways/adapter/model/Conf.kt
+++ b/src/main/kotlin/io/apiable/gateways/adapter/model/Conf.kt
@@ -24,9 +24,10 @@ Level 2 - Advanced - Mobile and Web Client - OAuth 2.0: Code Flow
 Level 3 - Evolved - Mobile and Web Client - Centralized Claims
 */
 enum class AuthType {
-    BASIC_API_KEY,
+    API_KEY,
     INTERMEDIATE_JWT,
-    INTERMEDIATE_CLIENT_CREDENTIAL,
+    CLIENT_SECRET_BASIC,
+    PRIVATE_KEY_JWT,
     ADVANCED_CODE_FLOW,
     EVOLVED_CENTRALIZED_CLAIMS
 }


### PR DESCRIPTION
## What

Renames the OIDC-aligned `AuthType` enum values and the `Auth*` subtype classes in the shared `apiable-gateway-api` adapter model, to match `token_endpoint_auth_method` (RFC 7591):

- `BASIC_API_KEY` → `API_KEY`
- `INTERMEDIATE_CLIENT_CREDENTIAL` → `CLIENT_SECRET_BASIC`
- adds `PRIVATE_KEY_JWT`
- `INTERMEDIATE_JWT`, `ADVANCED_CODE_FLOW`, `EVOLVED_CENTRALIZED_CLAIMS` unchanged

Files: `adapter/model/Conf.kt` (enum), `adapter/model/Auth.kt` (`Auth*` subtype classes), `adapter/Gateway.kt` (KDoc refresh).

## Why

Part of story **007-13-3** (Plan + Subscription authMethod migration). `apiable-gateway-api` is a shared dependency — `portal` imports these `AuthType` / `Auth*` types — so the rename has to land here first.

## Merge ordering — please merge this first

This PR must merge to `develop` **before** the sibling PRs for `portal`, `dashboard-2`, and `portal-client-ts` (all on branch `allanknabe/007-13-3/authmethod-migration`). Portal's CI resolves the `apiable-gateway-api` ref by branch-name match and falls back to `develop`; until this is on `develop`, the portal PR builds against the old enum and will not compile.

Story spec: `007-13-3-plan-subscription-authmethod-migration` in `apiable-documentation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
