### PR TITLE
[007-13-4] Add jwksUri to DcrClientMetadata (RFC 7591 dynamic client registration)

### DIFF
--- a/src/main/kotlin/io/apiable/authserver/adapter/DcrClientMetadata.kt
+++ b/src/main/kotlin/io/apiable/authserver/adapter/DcrClientMetadata.kt
@@ -14,6 +14,11 @@ data class DcrClientMetadata(
     val grantTypes: List<String> = listOf("client_credentials"),
     val tokenEndpointAuthMethod: String = "client_secret_basic",
     val redirectUris: List<String> = emptyList(),
+    /**
+     * RFC 7591 §2 `jwks_uri`. Populated when [tokenEndpointAuthMethod] is `private_key_jwt`
+     * so the auth provider knows which JWKS to verify signed client assertions against.
+     */
+    val jwksUri: String? = null,
     /** Provider-specific fields serialised alongside standard fields in the request body. */
     val providerExtras: Map<String, Any> = emptyMap(),
 )


### PR DESCRIPTION
## Summary

Mirrors backend changes from [portal#1868](https://github.com/apiable/portal/pull/1868) (story 007-13-4 — PRIVATE_KEY_JWT subscribe + DCR provisioning).

## Changes

- `DcrClientMetadata`: add `jwksUri: String? = null` (RFC 7591 `jwks_uri` field, populated for `token_endpoint_auth_method: 'private_key_jwt'` clients).

## Related

- Depends on backend [portal#1868](https://github.com/apiable/portal/pull/1868) (must merge in lockstep — portal's `KeycloakDcrClient.toAdminClientRepresentation` reads this field).
- Sibling: [portal-client-ts#TBD](../portal-client-ts) (`Subscription.jwksUri` + `AuthPrivateKeyJwt.registrationAccessToken` zod/interface additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)