### PR TITLE
007-12 m1: writeScopes() + WriteScopesResult on ScopeBindingAdapter

### DIFF
--- a/src/main/kotlin/io/apiable/authserver/adapter/ProviderScope.kt
+++ b/src/main/kotlin/io/apiable/authserver/adapter/ProviderScope.kt
@@ -1,6 +1,16 @@
 package io.apiable.authserver.adapter
 
+/**
+ * A scope as it exists at the Authorization Server provider.
+ *
+ * [includeInTokenScope] reflects whether the provider emits this scope into the access tokens it
+ * issues. A scope can exist at the provider yet be silently inert — present in the catalog but
+ * absent from every token's `scope` claim — in which case the resource server never sees the grant.
+ * Null means the provider has no such concept (or it was not read); callers treat a non-false value
+ * as "emitted". Keycloak maps it from the client scope's `include.in.token.scope` attribute.
+ */
 data class ProviderScope(
     val name: String,
     val description: String? = null,
+    val includeInTokenScope: Boolean? = null,
 )

--- a/src/main/kotlin/io/apiable/authserver/adapter/ScopeBindingAdapter.kt
+++ b/src/main/kotlin/io/apiable/authserver/adapter/ScopeBindingAdapter.kt
@@ -39,6 +39,34 @@ interface ScopeBindingAdapter {
     fun readAllProviderScopes(integrationId: String): ProviderScopeListResult
 
     /**
+     * Push Apiable-defined scope definitions into the provider's scope catalog —
+     * creating what is missing and updating what differs. The push half of provider
+     * scope management (the read half is [readAllProviderScopes]).
+     *
+     * Idempotent: a scope that already matches the incoming definition is left
+     * untouched; an existing scope whose description differs is updated.
+     *
+     * @param resourceServerName Apiable-side grouping name (Resource Group). Providers
+     *        with a native equivalent (Cognito Resource Server) SHOULD map it directly;
+     *        providers without one (Keycloak) MAY treat it as opaque metadata — log it
+     *        for traceability, but do NOT prefix scope names with it.
+     * @param scopes the scope definitions to create or update.
+     * @return [WriteScopesResult.Success] on partial or complete success — per-scope
+     *         failures surface in [WriteScopesResult.Success.errors] without aborting
+     *         the batch; [WriteScopesResult.Error] on total failure (auth, network),
+     *         in which case nothing was written.
+     * @throws UnsupportedOperationException if the adapter has not yet implemented the
+     *         write path. Callers MUST catch this and surface it as a user-facing 400.
+     */
+    fun writeScopes(
+        integrationId: String,
+        resourceServerName: String,
+        scopes: List<ProviderScope>,
+    ): WriteScopesResult = throw UnsupportedOperationException(
+        "writeScopes not yet supported for ${this::class.simpleName}",
+    )
+
+    /**
      * Check whether a client with the given OAuth2 clientId is registered with the provider.
      * Returns [ClientExistsResult.Found] if present, [ClientExistsResult.NotFound] if absent,
      * or [ClientExistsResult.Error] if the check itself could not complete (auth/network failure).

--- a/src/main/kotlin/io/apiable/authserver/adapter/WriteScopesResult.kt
+++ b/src/main/kotlin/io/apiable/authserver/adapter/WriteScopesResult.kt
@@ -1,0 +1,35 @@
+package io.apiable.authserver.adapter
+
+/**
+ * Outcome of pushing scope definitions into a provider's scope catalog via
+ * [ScopeBindingAdapter.writeScopes].
+ *
+ * [Success] covers both complete and partial success: a partial failure of one
+ * scope mid-batch surfaces in [Success.errors] rather than aborting the batch, so
+ * every scope that could be written is still committed. [Error] is reserved for a
+ * total failure where nothing was written (authentication failure, transport loss).
+ */
+sealed class WriteScopesResult {
+    data class Success(
+        val createdCount: Int,
+        val updatedCount: Int,
+        val deletedCount: Int,
+        val conflictCount: Int,
+        val errors: List<WriteScopeError> = emptyList(),
+    ) : WriteScopesResult()
+
+    data class Error(
+        val code: ScopeBindingErrorCode,
+        val message: String,
+        val cause: Throwable? = null,
+        val providerContext: Map<String, Any> = emptyMap(),
+    ) : WriteScopesResult()
+}
+
+/**
+ * A single scope that the provider rejected while the surrounding batch succeeded.
+ */
+data class WriteScopeError(
+    val scopeName: String,
+    val reason: String,
+)

--- a/src/main/kotlin/io/apiable/authserver/adapter/WriteScopesResult.kt
+++ b/src/main/kotlin/io/apiable/authserver/adapter/WriteScopesResult.kt
@@ -8,22 +8,34 @@ package io.apiable.authserver.adapter
  * scope mid-batch surfaces in [Success.errors] rather than aborting the batch, so
  * every scope that could be written is still committed. [Error] is reserved for a
  * total failure where nothing was written (authentication failure, transport loss).
+ *
+ * [kind] is a stable serialized discriminator so a client (portal-client-ts) can tell
+ * the two branches apart on the wire without provider-class type info. This library
+ * carries no serialization dependency; the consuming service owns wire concerns (e.g.
+ * the non-serializable [Error.cause] is mapped to a clean error DTO before it reaches
+ * a client).
  */
 sealed class WriteScopesResult {
+    abstract val kind: String
+
     data class Success(
         val createdCount: Int,
         val updatedCount: Int,
         val deletedCount: Int,
         val conflictCount: Int,
         val errors: List<WriteScopeError> = emptyList(),
-    ) : WriteScopesResult()
+    ) : WriteScopesResult() {
+        override val kind: String = "Success"
+    }
 
     data class Error(
         val code: ScopeBindingErrorCode,
         val message: String,
         val cause: Throwable? = null,
         val providerContext: Map<String, Any> = emptyMap(),
-    ) : WriteScopesResult()
+    ) : WriteScopesResult() {
+        override val kind: String = "Error"
+    }
 }
 
 /**


### PR DESCRIPTION
**Milestone 007-12 m1 — Stage 1 of 2 (shared contracts).** Foundation for epic 007-12 (Scope Beast: scope export + write primitive + bidirectional sync).

Adds the auth-server write-scope contract that portal's Keycloak adapter implements (story **007-12-2**):
- `ScopeBindingAdapter.writeScopes(...)` — create/heal realm client scopes
- `WriteScopesResult` — kind-tagged result wire type (success / partial / auth-error) for the client
- `ProviderScope` adjustment

Purely additive interface/types; `./gradlew build` green.

**Cross-repo ordering:** portal's backend (Stage 2) implements `writeScopes()` against this. Merge this **before** the portal PR so portal's `develop` build resolves the new adapter signature (CI resolves siblings by matching branch name, else `develop`).

**CI-sim:** production-readiness 007-12 = **GREEN**, re-verified 2026-06-15 — `apiable-documentation:_bmad-output/test-artifacts/production-readiness-007-12.md`.

_Review feedback lands on the epic branch `allanknabe/007-12/scope-export`, never this snapshot._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
